### PR TITLE
fix: correct -s interpretation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +113,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,12 +182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +192,15 @@ name = "linux-raw-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "memchr"
@@ -214,7 +242,8 @@ name = "pciutils"
 version = "0.1.0"
 dependencies = [
  "clap",
- "lazy_static",
+ "env_logger",
+ "log",
  "pci-ids",
  "pretty-hex",
  "regex",
@@ -341,6 +370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +389,37 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 clap = "4.2.1"
-lazy_static = "1.4.0"
+env_logger = "0.10.0"
+log = "0.4.17"
 pci-ids = "0.2.5"
 pretty-hex = "0.3.0"
 regex = "1"

--- a/src/bin/lspci.rs
+++ b/src/bin/lspci.rs
@@ -3,10 +3,14 @@ use pciutils::parser::Parser;
 use pciutils::sysfs::Sysfs;
 
 fn main() -> Result<()> {
+    env_logger::init();
+
     let parser = Parser::new();
 
-    let functions = Sysfs::discover()?;
-    let functions = parser.filter_slots(functions);
+    let mut functions = Sysfs::discover()?;
+    if let Some(slots) = parser.slots() {
+        functions.retain(|f| slots.clone().into_iter().any(|s| f.bdf == *s))
+    }
 
     for f in functions {
         println!("{}", f);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::{bdf::BusDeviceFunction, function::Function};
+use crate::bdf::BusDeviceFunction;
 use clap::{Arg, ArgMatches, Command};
 use std::str::FromStr;
 
@@ -25,14 +25,10 @@ impl Parser {
         }
     }
 
-    pub fn filter_slots(&self, functions: Vec<Function>) -> Vec<Function> {
-        match self.matches.get_many::<BusDeviceFunction>("slot") {
-            Some(mut slots) => functions
-                .into_iter()
-                .filter(|function| slots.any(|slot| function.bdf == *slot))
-                .collect(),
-            None => functions,
-        }
+    pub fn slots(&self) -> Option<Vec<&BusDeviceFunction>> {
+        self.matches
+            .get_many::<BusDeviceFunction>("slot")
+            .map(|s| s.collect())
     }
 }
 

--- a/src/sysfs.rs
+++ b/src/sysfs.rs
@@ -39,7 +39,7 @@ impl Sysfs {
     fn get_function_sub_path(bdf: &BusDeviceFunction, sub: &str) -> PathBuf {
         let mut path: PathBuf = Self::PCI_FUNCTIONS_PATH.into();
 
-        path.push(bdf.bdf_string_with_domain());
+        path.push(bdf.canonical_bdf_string());
         path.push(sub);
 
         path


### PR DESCRIPTION
The -s (slot) parameter can be used like a wild card, so correct the parsing to behave like a wild card:

$ cargo run --bin lspci -- -s .3
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/lspci -s .3`
0000:00:14.3 Network controller: Intel Corporation Alder Lake-P PCH CNVi WiFi (rev 01) 0000:00:1f.3 Audio device: Intel Corporation Alder Lake PCH-P High Definition Audio Controller (rev 01)

$ cargo run --bin lspci -- -s 14
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/lspci -s 14`
0000:00:14.0 USB controller: Intel Corporation Alder Lake PCH USB 3.2 xHCI Host Controller (rev 01) 0000:00:14.2 RAM memory: Intel Corporation Alder Lake PCH Shared SRAM (rev 01) 0000:00:14.3 Network controller: Intel Corporation Alder Lake-P PCH CNVi WiFi (rev 01)

$ cargo run --bin lspci -- -s 1:
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/lspci -s '1:'`
0000:01:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller SM981/PM981/PM983