### PR TITLE
feat: add id support

### DIFF
--- a/src/bin/lspci.rs
+++ b/src/bin/lspci.rs
@@ -8,8 +8,13 @@ fn main() -> Result<()> {
     let parser = Parser::new();
 
     let mut functions = Sysfs::discover()?;
+
     if let Some(slots) = parser.slots() {
-        functions.retain(|f| slots.clone().into_iter().any(|s| f.bdf == *s))
+        functions.retain(|function| slots.clone().into_iter().any(|slot| *function == *slot))
+    }
+
+    if let Some(ids) = parser.ids() {
+        functions.retain(|function| ids.clone().into_iter().any(|id| *function == *id))
     }
 
     for f in functions {

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum ErrorKind {
     IntegerParseError,
     InvalidBusDeviceFunction,
+    InvalidVendorDeviceClass,
     IoError(i32),
     FormatError,
 }
@@ -22,6 +23,13 @@ impl Error {
     pub fn invalid_bdf(message: &str) -> Self {
         Error {
             error_kind: ErrorKind::InvalidBusDeviceFunction,
+            message: message.to_string(),
+        }
+    }
+
+    pub fn invalid_vdc(message: &str) -> Self {
+        Error {
+            error_kind: ErrorKind::InvalidVendorDeviceClass,
             message: message.to_string(),
         }
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,11 +1,12 @@
 use crate::error::Result;
+use crate::vdc::VendorDeviceClass;
 use crate::{bdf::BusDeviceFunction, sysfs::Sysfs};
 use pci_ids::{Device, FromId, Subclass, Vendor};
 use std::fmt::Display;
 
 #[derive(Debug)]
 pub struct Function {
-    pub bdf: BusDeviceFunction,
+    bdf: BusDeviceFunction,
     accessor: Sysfs,
 }
 
@@ -26,8 +27,12 @@ impl Function {
         self.accessor.revision_id(&self.bdf)
     }
 
-    pub fn class_code(&self) -> Result<u8> {
+    pub fn class_code(&self) -> Result<u16> {
         self.accessor.class_code(&self.bdf)
+    }
+
+    pub fn base_class_code(&self) -> Result<u8> {
+        self.accessor.base_class_code(&self.bdf)
     }
 
     pub fn sub_class_code(&self) -> Result<u8> {
@@ -39,7 +44,7 @@ impl Function {
     }
 
     pub fn brief(&self) -> Result<String> {
-        let base_class_id = self.class_code()?;
+        let base_class_id = self.base_class_code()?;
         let sub_class_id = self.sub_class_code()?;
         let vendor_id = self.vendor_id()?;
         let device_id = self.device_id()?;
@@ -78,5 +83,35 @@ impl Function {
 impl Display for Function {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.brief()?)
+    }
+}
+
+impl PartialEq<VendorDeviceClass> for Function {
+    fn eq(&self, other: &VendorDeviceClass) -> bool {
+        let vendor_eq = other.vendor.is_none()
+            || other.vendor.unwrap()
+                == self.vendor_id().unwrap_or_else(|_| {
+                    panic!("Cannot read vendor id for {}", self.brief().unwrap())
+                });
+
+        let device_eq = other.device.is_none()
+            || other.device.unwrap()
+                == self.device_id().unwrap_or_else(|_| {
+                    panic!("Cannot read device id for {}", self.brief().unwrap())
+                });
+
+        let class_eq = other.class.is_none()
+            || other.class.unwrap()
+                == self.class_code().unwrap_or_else(|_| {
+                    panic!("Cannot read class code for {}", self.brief().unwrap())
+                });
+
+        vendor_eq && device_eq && class_eq
+    }
+}
+
+impl PartialEq<BusDeviceFunction> for Function {
+    fn eq(&self, other: &BusDeviceFunction) -> bool {
+        self.bdf == *other
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod error;
 pub mod function;
 pub mod parser;
 pub mod sysfs;
+pub mod vdc;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::bdf::BusDeviceFunction;
+use crate::{bdf::BusDeviceFunction, vdc::VendorDeviceClass};
 use clap::{Arg, ArgMatches, Command};
 use std::str::FromStr;
 
@@ -14,11 +14,22 @@ impl Parser {
                     Arg::new("slot")
                         .short('s')
                         .help(format!(
-                            "{} {}",
+                            "{}\t{}",
                             BusDeviceFunction::FORMAT,
                             "Show only devices in selected slots"
                         ))
                         .value_parser(BusDeviceFunction::from_str)
+                        .action(clap::ArgAction::Append),
+                )
+                .arg(
+                    Arg::new("id")
+                        .short('d')
+                        .help(format!(
+                            "{}\t{}",
+                            VendorDeviceClass::FORMAT,
+                            "Show only devices with specified ID's"
+                        ))
+                        .value_parser(VendorDeviceClass::from_str)
                         .action(clap::ArgAction::Append),
                 )
                 .get_matches(),
@@ -29,6 +40,12 @@ impl Parser {
         self.matches
             .get_many::<BusDeviceFunction>("slot")
             .map(|s| s.collect())
+    }
+
+    pub fn ids(&self) -> Option<Vec<&VendorDeviceClass>> {
+        self.matches
+            .get_many::<VendorDeviceClass>("id")
+            .map(|id| id.collect())
     }
 }
 

--- a/src/sysfs.rs
+++ b/src/sysfs.rs
@@ -78,14 +78,17 @@ impl Sysfs {
         Self::parse_function_parameter_u8(bdf, "revision")
     }
 
-    pub fn class_code(&self, bdf: &BusDeviceFunction) -> Result<u8> {
+    pub fn class_code(&self, bdf: &BusDeviceFunction) -> Result<u16> {
         let class_code = Self::parse_function_parameter_u32(bdf, "class")?;
-        Ok((class_code >> 16).try_into().unwrap())
+        Ok(((class_code >> 8) & 0xffff).try_into().unwrap())
+    }
+
+    pub fn base_class_code(&self, bdf: &BusDeviceFunction) -> Result<u8> {
+        Ok(((self.class_code(bdf)? >> 8) & 0xff).try_into().unwrap())
     }
 
     pub fn sub_class_code(&self, bdf: &BusDeviceFunction) -> Result<u8> {
-        let class_code = Self::parse_function_parameter_u32(bdf, "class")?;
-        Ok(((class_code >> 8) & 0xff).try_into().unwrap())
+        Ok((self.class_code(bdf)? & 0xff).try_into().unwrap())
     }
 
     pub fn config(&self, bdf: &BusDeviceFunction) -> Result<Vec<u8>> {

--- a/src/vdc.rs
+++ b/src/vdc.rs
@@ -1,0 +1,71 @@
+use crate::error::{Error, Result};
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub struct VendorDeviceClass {
+    pub vendor: Option<u16>,
+    pub device: Option<u16>,
+    pub class: Option<u16>,
+}
+
+impl VendorDeviceClass {
+    pub const FORMAT: &str = "[<vendor>]:[<device>][:<class>]";
+    fn from_str(s: &str) -> Result<Self> {
+        let mut parts: Vec<_> = s.split(':').collect();
+
+        if parts.len() < 2 || parts.len() > 3 {
+            return Err(Error::invalid_vdc(s));
+        }
+
+        let mut class = None;
+        if parts.len() == 3 {
+            if let Some(part) = parts.pop() {
+                if !part.is_empty() {
+                    class = Some(u16::from_str_radix(part, 16).map_err(|_| Error::invalid_bdf(s))?);
+                }
+            }
+        }
+
+        let mut device = None;
+        if let Some(part) = parts.pop() {
+            if !part.is_empty() {
+                device = Some(u16::from_str_radix(part, 16).map_err(|_| Error::invalid_bdf(s))?);
+            }
+        }
+
+        let mut vendor = None;
+        if let Some(part) = parts.pop() {
+            if !part.is_empty() {
+                vendor = Some(u16::from_str_radix(part, 16).map_err(|_| Error::invalid_bdf(s))?);
+            }
+        }
+
+        Ok(VendorDeviceClass {
+            vendor,
+            device,
+            class,
+        })
+    }
+}
+
+impl FromStr for VendorDeviceClass {
+    type Err = std::io::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Self::from_str(s).map_err(std::io::Error::from)
+    }
+}
+
+impl PartialEq for VendorDeviceClass {
+    fn eq(&self, other: &Self) -> bool {
+        (self.vendor.is_none()
+            || other.vendor.is_none()
+            || self.vendor.unwrap() == other.vendor.unwrap())
+            && (self.device.is_none()
+                || other.device.is_none()
+                || self.device.unwrap() == other.device.unwrap())
+            && (self.class.is_none()
+                || other.class.is_none()
+                || self.class.unwrap() == other.class.unwrap())
+    }
+}


### PR DESCRIPTION
Add the ability to filter based on [<vendor>]:[<device>][:<class>] specification:

$ cargo run --bin lspci -- -d 1217:
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/lspci -d '1217:'`
0000:2d:00.0 SD Host controller: O2 Micro, Inc. SD/MMC Card Reader Controller (rev 01)