### PR TITLE
feat: add basic hexdump capability

### DIFF
--- a/src/bin/lspci.rs
+++ b/src/bin/lspci.rs
@@ -2,6 +2,8 @@ use pciutils::error::Result;
 use pciutils::parser::Parser;
 use pciutils::sysfs::Sysfs;
 
+use pretty_hex::{config_hex, HexConfig};
+
 fn main() -> Result<()> {
     env_logger::init();
 
@@ -17,8 +19,18 @@ fn main() -> Result<()> {
         functions.retain(|function| ids.clone().into_iter().any(|id| *function == *id))
     }
 
+    let hex_config = HexConfig {
+        title: false,
+        width: 16,
+        group: 0,
+        ascii: false,
+        ..HexConfig::default()
+    };
     for f in functions {
         println!("{}", f);
+        if parser.hexdump() {
+            println!("{}", config_hex(&f.config()?, hex_config))
+        }
     }
 
     Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,9 +14,9 @@ impl Parser {
                     Arg::new("slot")
                         .short('s')
                         .help(format!(
-                            "{}\t{}",
+                            "{} {}",
+                            "Show only devices in selected slots",
                             BusDeviceFunction::FORMAT,
-                            "Show only devices in selected slots"
                         ))
                         .value_parser(BusDeviceFunction::from_str)
                         .action(clap::ArgAction::Append),
@@ -25,12 +25,18 @@ impl Parser {
                     Arg::new("id")
                         .short('d')
                         .help(format!(
-                            "{}\t{}",
+                            "{} {}",
+                            "Show only devices with specified ID's",
                             VendorDeviceClass::FORMAT,
-                            "Show only devices with specified ID's"
                         ))
                         .value_parser(VendorDeviceClass::from_str)
                         .action(clap::ArgAction::Append),
+                )
+                .arg(
+                    Arg::new("hexdump")
+                        .short('x')
+                        .help("Show hex-dump of the standard part of the config space".to_string())
+                        .action(clap::ArgAction::SetTrue),
                 )
                 .get_matches(),
         }
@@ -46,6 +52,10 @@ impl Parser {
         self.matches
             .get_many::<VendorDeviceClass>("id")
             .map(|id| id.collect())
+    }
+
+    pub fn hexdump(&self) -> bool {
+        self.matches.get_flag("hexdump")
     }
 }
 


### PR DESCRIPTION
Add the ability to dump the basic configuration space. This matches the -x behaviour of pciutils lspci and operates without need for root access.

$ cargo run --bin lspci -- -d 1217: -x
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/lspci -d '1217:' -x`
0000:2d:00.0 SD Host controller: O2 Micro, Inc. SD/MMC Card Reader Controller (rev 01)
0000:   17 12 21 86 06 04 10 00 01 01 05 08 10 00 00 00
0010:   00 00 50 80 00 10 50 80 00 00 00 00 00 00 00 00
0020:   00 00 00 00 00 00 00 00 00 00 00 00 17 12 02 00
0030:   00 00 00 00 6c 00 00 00 00 00 00 00 0b 01 00 00