### PR TITLE
fix: add empty line after hexdump

### DIFF
--- a/src/bin/lspci.rs
+++ b/src/bin/lspci.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
     for f in functions {
         println!("{}", f);
         if parser.hexdump() {
-            println!("{}", config_hex(&f.config()?, hex_config))
+            println!("{}\n", config_hex(&f.config()?, hex_config))
         }
     }
 


### PR DESCRIPTION
The hexdump output should be separated from the next line by an empty line for ease of reading and to match original pciutils output.