### PR TITLE
feat: start verbose support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,6 @@ dependencies = [
  "log",
  "pci-ids",
  "pretty-hex",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ env_logger = "0.10.0"
 log = "0.4.17"
 pci-ids = "0.2.5"
 pretty-hex = "0.3.0"
-regex = "1"
 

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -1,0 +1,67 @@
+#[derive(Debug, PartialEq)]
+pub struct MemBAR<T> {
+    pub address: T,
+    pub prefechable: bool,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum BAR {
+    MemBAR32(MemBAR<u32>),
+    MemBAR64(MemBAR<u64>),
+    IoBAR(u32),
+}
+
+impl BAR {
+    fn is_io_bar(word: u32) -> bool {
+        word & 0b1 == 0b1
+    }
+
+    fn is_32bit_mem_bar(word: u32) -> bool {
+        word & 0b10 == 0b00
+    }
+
+    fn io_bar(word: u32) -> BAR {
+        if word & 0b10 == 0b10 {
+            log::warn!("Rserved bit set");
+        }
+
+        BAR::IoBAR(word & !0b11)
+    }
+
+    fn mem_32bit_bar(word: u32) -> BAR {
+        BAR::MemBAR32(MemBAR {
+            address: word & !0b1111,
+            prefechable: word & 0b1000 == 0b1000,
+        })
+    }
+
+    fn mem_64bit_bar(word0: u32, word1: u32) -> BAR {
+        BAR::MemBAR64(MemBAR {
+            address: (word1 as u64) << 32 | (word0 & !0b1111) as u64,
+            prefechable: word0 & 0b1000 == 0b1000,
+        })
+    }
+
+    pub fn new(b: &[u8]) -> Vec<BAR> {
+        let mut offset = 0;
+        let mut bars = vec![];
+
+        while offset < b.len() {
+            let word = u32::from_le_bytes(b[offset..offset + 4].try_into().unwrap());
+            if Self::is_io_bar(word) {
+                bars.push(Self::io_bar(word));
+                offset += 4;
+            } else if Self::is_32bit_mem_bar(word) {
+                bars.push(Self::mem_32bit_bar(word));
+                offset += 4;
+            } else {
+                offset += 4;
+                let next_word = u32::from_le_bytes(b[offset..offset + 4].try_into().unwrap());
+                bars.push(Self::mem_64bit_bar(word, next_word));
+                offset += 4;
+            }
+        }
+
+        bars
+    }
+}

--- a/src/bdf.rs
+++ b/src/bdf.rs
@@ -18,9 +18,15 @@ impl BusDeviceFunction {
         self.bus
     }
 
-    pub fn bdf_string(&self) -> String {
+    pub fn bdf_string(&self, always_domain: bool) -> String {
         let domain = match self.domain {
-            Some(domain) => format!("{:0>4x}:", domain),
+            Some(domain) => {
+                if domain == 0 && !always_domain {
+                    String::new()
+                } else {
+                    format!("{:0>4x}:", domain)
+                }
+            }
             None => String::new(),
         };
 
@@ -45,13 +51,7 @@ impl BusDeviceFunction {
     }
 
     pub fn canonical_bdf_string(&self) -> String {
-        if self.domain.is_none() {
-            let mut bdf = self.clone();
-            bdf.domain = Some(0);
-            return bdf.bdf_string();
-        }
-
-        self.bdf_string()
+        self.bdf_string(true)
     }
 
     fn from_str(s: &str) -> Result<Self> {
@@ -137,7 +137,7 @@ impl FromStr for BusDeviceFunction {
 
 impl Display for BusDeviceFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.bdf_string())
+        write!(f, "{}", self.bdf_string(false))
     }
 }
 

--- a/src/bdf.rs
+++ b/src/bdf.rs
@@ -13,6 +13,11 @@ pub struct BusDeviceFunction {
 
 impl BusDeviceFunction {
     pub const FORMAT: &str = "[[[[<domain>]:]<bus>]:][<slot>][.[<func>]]";
+
+    pub fn bus(&self) -> Option<u8> {
+        self.bus
+    }
+
     pub fn bdf_string(&self) -> String {
         let domain = match self.domain {
             Some(domain) => format!("{:0>4x}:", domain),

--- a/src/bin/lspci.rs
+++ b/src/bin/lspci.rs
@@ -27,9 +27,13 @@ fn main() -> Result<()> {
         ..HexConfig::default()
     };
     for f in functions {
-        println!("{}", f);
-        if parser.hexdump() {
-            println!("{}\n", config_hex(&f.config()?, hex_config))
+        println!("{}", f.to_string(parser.verbosity())?);
+        if parser.hexdump() > 0 {
+            println!("{}", config_hex(&f.config()?, hex_config))
+        }
+
+        if parser.hexdump() > 0 || parser.verbosity() > 0 {
+            println!();
         }
     }
 

--- a/src/caps/binary_parser.rs
+++ b/src/caps/binary_parser.rs
@@ -1,0 +1,24 @@
+use crate::error::{Error, Result};
+use std::ops::Range;
+
+pub struct BinaryParser;
+
+impl BinaryParser {
+    pub fn le32(b: &[u8], r: Range<usize>) -> Result<u32> {
+        Ok(u32::from_le_bytes(
+            (*b.get(r.clone()).ok_or(Error::slice_parse_error(b, &r))?).try_into()?,
+        ))
+    }
+
+    pub fn le16(b: &[u8], r: Range<usize>) -> Result<u16> {
+        Ok(u16::from_le_bytes(
+            (*b.get(r.clone()).ok_or(Error::slice_parse_error(b, &r))?).try_into()?,
+        ))
+    }
+
+    pub fn le8(b: &[u8], r: Range<usize>) -> Result<u8> {
+        Ok(u8::from_le_bytes(
+            (*b.get(r.clone()).ok_or(Error::slice_parse_error(b, &r))?).try_into()?,
+        ))
+    }
+}

--- a/src/caps/header.rs
+++ b/src/caps/header.rs
@@ -1,0 +1,391 @@
+use crate::bar::BAR;
+use crate::caps::binary_parser::BinaryParser;
+use crate::error::{Error, Result};
+use pci_ids::{Device, FromId, Subclass, Vendor};
+use std::ops::Range;
+
+pub trait CommonHeader {
+    const HEADER_TYPE_LAYOUT_MASK: u8 = 0b0111_1111;
+
+    fn get_raw(&self) -> &[u8];
+    fn bars(&self) -> Result<Vec<BAR>>;
+    fn to_string(&self, verbosity: u8) -> Result<String>;
+
+    fn vendor_id(&self) -> Result<u16> {
+        BinaryParser::le16(
+            self.get_raw(),
+            Range {
+                start: 0x000,
+                end: 0x002,
+            },
+        )
+    }
+
+    fn device_id(&self) -> Result<u16> {
+        BinaryParser::le16(
+            self.get_raw(),
+            Range {
+                start: 0x002,
+                end: 0x004,
+            },
+        )
+    }
+
+    fn command(&self) -> Result<u16> {
+        BinaryParser::le16(
+            self.get_raw(),
+            Range {
+                start: 0x004,
+                end: 0x006,
+            },
+        )
+    }
+
+    fn status(&self) -> Result<u16> {
+        BinaryParser::le16(
+            self.get_raw(),
+            Range {
+                start: 0x006,
+                end: 0x008,
+            },
+        )
+    }
+
+    fn revision_id(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x008,
+                end: 0x009,
+            },
+        )
+    }
+
+    fn programming_interface(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x009,
+                end: 0x00A,
+            },
+        )
+    }
+
+    fn sub_class_code(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x00A,
+                end: 0x00B,
+            },
+        )
+    }
+
+    fn base_class_code(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x00B,
+                end: 0x00C,
+            },
+        )
+    }
+
+    fn header_type(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x000E,
+                end: 0x000F,
+            },
+        )
+    }
+
+    fn capability_pointer(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x034,
+                end: 0x035,
+            },
+        )
+    }
+
+    fn vendor_name(&self) -> Result<String> {
+        let vendor_id = self.vendor_id()?;
+        let vendor = match Vendor::from_id(vendor_id) {
+            Some(vendor) => vendor.name().to_string(),
+            None => format!("Vendor {:0>4x}", vendor_id),
+        };
+
+        Ok(vendor)
+    }
+
+    fn device_string(&self) -> Result<String> {
+        let base_class_id = self.base_class_code()?;
+        let sub_class_id = self.sub_class_code()?;
+        let sub_class = match Subclass::from_cid_sid(base_class_id, sub_class_id) {
+            Some(sub_class) => sub_class.name().to_string(),
+            None => format!("SubClass {:0>2x}", sub_class_id),
+        };
+
+        let vendor_id = self.vendor_id()?;
+        let device_id = self.device_id()?;
+        let device = match Device::from_vid_pid(vendor_id, device_id) {
+            Some(device) => device.name().to_string(),
+            None => format!("Device {:0>4x}", device_id),
+        };
+
+        let revision_id = self.revision_id()?;
+        let revision = if revision_id > 0 {
+            format!("(rev {:0>2x})", revision_id)
+        } else {
+            String::new()
+        };
+
+        let text = format!(
+            "{}: {} {} {}",
+            sub_class,
+            self.vendor_name()?,
+            device,
+            revision
+        )
+        .trim()
+        .to_string();
+
+        Ok(text)
+    }
+
+    fn header_layout(b: &[u8]) -> Result<u8> {
+        let layout = BinaryParser::le8(
+            b,
+            Range {
+                start: 0x00E,
+                end: 0x00F,
+            },
+        )?;
+
+        Ok(layout & Self::HEADER_TYPE_LAYOUT_MASK)
+    }
+}
+
+#[derive(Debug)]
+pub struct Type0Header {
+    raw: Vec<u8>,
+}
+
+impl CommonHeader for Type0Header {
+    fn get_raw(&self) -> &[u8] {
+        &self.raw
+    }
+
+    fn bars(&self) -> Result<Vec<BAR>> {
+        let range = Range {
+            start: 0x010,
+            end: 0x028,
+        };
+        Ok(BAR::new(
+            self.raw
+                .get(range.clone())
+                .ok_or(Error::slice_parse_error(&self.raw, &range))?,
+        ))
+    }
+
+    fn to_string(&self, verbosity: u8) -> Result<String> {
+        let mut text = self.device_string()?;
+
+        if verbosity >= 1 {
+            text = format!("{}\n\t{}", text, self.subsytem_string()?);
+        }
+
+        Ok(text.trim().to_string())
+    }
+}
+
+impl Type0Header {
+    pub fn new(b: &[u8]) -> Result<Self> {
+        Ok(Self { raw: b.to_vec() })
+    }
+
+    pub fn subsystem_vendor_id(&self) -> Result<u16> {
+        BinaryParser::le16(
+            self.get_raw(),
+            Range {
+                start: 0x02C,
+                end: 0x02E,
+            },
+        )
+    }
+
+    pub fn subsystem_id(&self) -> Result<u16> {
+        BinaryParser::le16(
+            self.get_raw(),
+            Range {
+                start: 0x02E,
+                end: 0x030,
+            },
+        )
+    }
+
+    fn subsytem_string(&self) -> Result<String> {
+        let subsystem_device = self.subsystem_id()?;
+        let subsystem_vendor = self.subsystem_vendor_id()?;
+
+        let device_id = self.device_id()?;
+        let vendor_id = self.vendor_id()?;
+
+        let device = Device::from_vid_pid(vendor_id, device_id);
+        if device.is_none() {
+            return Ok(format!(
+                "Subsystem: {} Device {:0>4x}",
+                self.vendor_name()?,
+                subsystem_device
+            ));
+        }
+
+        let device = device.unwrap();
+        if let Some(device) = device
+            .subsystems()
+            .find(|d| d.subdevice() == subsystem_device)
+        {
+            return Ok(format!(
+                "Subsystem: {} {}",
+                self.vendor_name()?,
+                device.name()
+            ));
+        }
+
+        Ok(format!(
+            "Subsystem: Vendor {:0>4x} Device {:0>4x}",
+            subsystem_vendor, subsystem_device
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub struct Type1Header {
+    raw: Vec<u8>,
+}
+
+impl CommonHeader for Type1Header {
+    fn get_raw(&self) -> &[u8] {
+        &self.raw
+    }
+
+    fn bars(&self) -> Result<Vec<BAR>> {
+        let range = Range {
+            start: 0x010,
+            end: 0x014,
+        };
+        Ok(BAR::new(
+            self.raw
+                .get(range.clone())
+                .ok_or(Error::slice_parse_error(&self.raw, &range))?,
+        ))
+    }
+
+    fn to_string(&self, verbosity: u8) -> Result<String> {
+        let mut text = self.device_string()?;
+
+        if verbosity >= 1 {
+            text = format!("{}\n\t{}", text, self.bus_string()?);
+        }
+
+        Ok(text.trim().to_string())
+    }
+}
+
+impl Type1Header {
+    pub fn new(b: &[u8]) -> Result<Self> {
+        Ok(Self { raw: b.to_vec() })
+    }
+
+    pub fn primary_bus_number(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x018,
+                end: 0x019,
+            },
+        )
+    }
+
+    pub fn secondary_bus_number(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x019,
+                end: 0x01A,
+            },
+        )
+    }
+
+    pub fn subordinate_bus_number(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x01A,
+                end: 0x01B,
+            },
+        )
+    }
+
+    pub fn secondary_latency_timer(&self) -> Result<u8> {
+        BinaryParser::le8(
+            self.get_raw(),
+            Range {
+                start: 0x01B,
+                end: 0x01C,
+            },
+        )
+    }
+
+    fn bus_string(&self) -> Result<String> {
+        Ok(format!(
+            "Bus: primary={:0>2x}, secondary={:0>2x}, subordiante={:0>2x}, sec-latency={}",
+            self.primary_bus_number()?,
+            self.secondary_bus_number()?,
+            self.subordinate_bus_number()?,
+            self.secondary_latency_timer()?,
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub enum Header {
+    Type0(Type0Header),
+    Type1(Type1Header),
+}
+
+impl Header {
+    pub fn new(b: &[u8]) -> Result<Self> {
+        if <Type0Header as CommonHeader>::header_layout(b)? == 0 {
+            Ok(Header::Type0(Type0Header::new(b)?))
+        } else {
+            Ok(Header::Type1(Type1Header::new(b)?))
+        }
+    }
+}
+
+impl CommonHeader for Header {
+    fn get_raw(&self) -> &[u8] {
+        match self {
+            Header::Type0(h) => h.get_raw(),
+            Header::Type1(h) => h.get_raw(),
+        }
+    }
+
+    fn bars(&self) -> Result<Vec<BAR>> {
+        match self {
+            Header::Type0(h) => h.bars(),
+            Header::Type1(h) => h.bars(),
+        }
+    }
+
+    fn to_string(&self, verbosity: u8) -> Result<String> {
+        match self {
+            Header::Type0(h) => h.to_string(verbosity),
+            Header::Type1(h) => h.to_string(verbosity),
+        }
+    }
+}

--- a/src/caps/mod.rs
+++ b/src/caps/mod.rs
@@ -1,0 +1,2 @@
+pub mod binary_parser;
+pub mod header;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::convert::From;
 use std::fmt::Debug;
 use std::num::ParseIntError;
+use std::ops::Range;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -9,14 +10,15 @@ pub enum ErrorKind {
     IntegerParseError,
     InvalidBusDeviceFunction,
     InvalidVendorDeviceClass,
-    IoError(i32),
+    IoError(std::io::ErrorKind),
     FormatError,
+    SliceParseError,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct Error {
-    error_kind: ErrorKind,
-    message: String,
+    pub error_kind: ErrorKind,
+    pub message: String,
 }
 
 impl Error {
@@ -33,6 +35,22 @@ impl Error {
             message: message.to_string(),
         }
     }
+
+    pub fn is_file_not_found(&self) -> bool {
+        if let ErrorKind::IoError(std::io::ErrorKind::NotFound) = self.error_kind {
+            return true;
+        }
+
+        false
+    }
+
+    pub fn slice_parse_error(b: &[u8], r: &Range<usize>) -> Error {
+        let message = format!("Index range {}:{} outside of 0:{}", r.start, r.end, b.len());
+        Error {
+            error_kind: ErrorKind::SliceParseError,
+            message,
+        }
+    }
 }
 
 impl From<ParseIntError> for Error {
@@ -47,7 +65,7 @@ impl From<ParseIntError> for Error {
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
         Error {
-            error_kind: ErrorKind::IoError(value.raw_os_error().unwrap_or_default()),
+            error_kind: ErrorKind::IoError(value.kind()),
             message: value.to_string(),
         }
     }
@@ -71,5 +89,14 @@ impl From<std::fmt::Error> for Error {
 impl From<Error> for std::fmt::Error {
     fn from(_: Error) -> Self {
         std::fmt::Error {}
+    }
+}
+
+impl From<std::array::TryFromSliceError> for Error {
+    fn from(value: std::array::TryFromSliceError) -> Self {
+        Error {
+            error_kind: ErrorKind::SliceParseError,
+            message: value.to_string(),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod bar;
 pub mod bdf;
+pub mod caps;
 pub mod error;
 pub mod function;
 pub mod parser;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -36,7 +36,13 @@ impl Parser {
                     Arg::new("hexdump")
                         .short('x')
                         .help("Show hex-dump of the standard part of the config space".to_string())
-                        .action(clap::ArgAction::SetTrue),
+                        .action(clap::ArgAction::Count),
+                )
+                .arg(
+                    Arg::new("verbose")
+                        .short('v')
+                        .help("Be verbose".to_string())
+                        .action(clap::ArgAction::Count),
                 )
                 .get_matches(),
         }
@@ -54,8 +60,12 @@ impl Parser {
             .map(|id| id.collect())
     }
 
-    pub fn hexdump(&self) -> bool {
-        self.matches.get_flag("hexdump")
+    pub fn hexdump(&self) -> u8 {
+        self.matches.get_count("hexdump")
+    }
+
+    pub fn verbosity(&self) -> u8 {
+        self.matches.get_count("verbose")
     }
 }
 


### PR DESCRIPTION
This change adds miniam verbosity support to the output:

$ cargo run --bin lspci -- -v -s02:00.0
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/lspci -v '-s02:00.0'`
0000:02:00.0 PCI bridge: Intel Corporation JHL7540 Thunderbolt 3 Bridge [Titan Ridge DD 2018] (rev 06)
        Bus: primary=02, secondary=03, subordiante=04, sec-latency=0

$ lspci -v -s02:00.0
02:00.0 PCI bridge: Intel Corporation JHL7540 Thunderbolt 3 Bridge [Titan Ridge DD 2018] (rev 06) (prog-if 00 [Normal decode])
        Physical Slot: 3
        Flags: bus master, fast devsel, latency 0, IRQ 20, IOMMU group 16
        Bus: primary=02, secondary=03, subordinate=04, sec-latency=0
        I/O behind bridge: 00002000-00003fff [size=8K]
        Memory behind bridge: 82000000-8e1fffff [size=194M]
        Prefetchable memory behind bridge: 0000000a7fc00000-0000000a9bbfffff [size=448M]
        Capabilities: <access denied>
        Kernel driver in use: pcieport