### PR TITLE
feat: add kernel driver and module information

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,0 +1,59 @@
+use crate::bdf::BusDeviceFunction;
+use crate::error::Result;
+use crate::sysfs::Sysfs;
+use std::fs::read_link;
+
+#[derive(Debug)]
+pub struct Kernel;
+
+impl Kernel {
+    pub fn text(&self, bdf: &BusDeviceFunction, verbosity: u8) -> Result<String> {
+        Ok(format!(
+            "{}\n{}",
+            self.driver_text(bdf, verbosity)?,
+            self.module_text(bdf, verbosity)?
+        ))
+    }
+
+    pub fn driver_text(&self, bdf: &BusDeviceFunction, verbosity: u8) -> Result<String> {
+        if verbosity == 0 {
+            return Ok(String::new());
+        }
+
+        let driver_symlink = Sysfs::get_function_sub_path(bdf, "driver");
+        let driver_path = read_link(driver_symlink);
+
+        if driver_path.is_err() {
+            return Ok(String::new());
+        }
+
+        let driver_path = driver_path?;
+        let driver_path = driver_path.to_str().unwrap_or_default();
+
+        Ok(format!(
+            "\tKernel driver in use: {}",
+            driver_path.split('/').last().unwrap_or_default()
+        ))
+    }
+
+    pub fn module_text(&self, bdf: &BusDeviceFunction, verbosity: u8) -> Result<String> {
+        if verbosity == 0 {
+            return Ok(String::new());
+        }
+
+        let module_symlink = Sysfs::get_function_sub_path(bdf, "driver/module");
+        let module_path = read_link(module_symlink);
+
+        if module_path.is_err() {
+            return Ok(String::new());
+        }
+
+        let module_path = module_path?;
+        let module_path = module_path.to_str().unwrap_or_default();
+
+        Ok(format!(
+            "\tKernel modules: {}",
+            module_path.split('/').last().unwrap_or_default()
+        ))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bdf;
 pub mod caps;
 pub mod error;
 pub mod function;
+pub mod kernel;
 pub mod parser;
 pub mod sysfs;
 pub mod vdc;

--- a/src/sysfs.rs
+++ b/src/sysfs.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use crate::bdf::BusDeviceFunction;
 use crate::error::Result;
 use crate::function::Function;
+use crate::kernel::Kernel;
 
 #[derive(Debug)]
 pub struct Sysfs;
@@ -32,13 +33,13 @@ impl Sysfs {
 
         let mut functions = vec![];
         for bdf in bdfs {
-            functions.push(Function::new(bdf, Self)?);
+            functions.push(Function::new(bdf, Self, Kernel)?);
         }
 
         Ok(functions)
     }
 
-    fn get_function_sub_path(bdf: &BusDeviceFunction, sub: &str) -> PathBuf {
+    pub fn get_function_sub_path(bdf: &BusDeviceFunction, sub: &str) -> PathBuf {
         let mut path: PathBuf = Self::PCI_FUNCTIONS_PATH.into();
 
         path.push(bdf.canonical_bdf_string());


### PR DESCRIPTION
Add the ability to dump kernel driver and module information when using verbose output.

$ cargo run --bin lspci -- -vs00:14.3
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/lspci '-vs00:14.3'`
00:14.3 Network controller: Intel Corporation Alder Lake-P PCH CNVi WiFi (rev 01)
        Subsystem: Intel Corporation Wi-Fi 6 AX201 160MHz
        Kernel driver in use: iwlwifi
        Kernel modules: iwlwifi