### PR TITLE
feat: minimal BAR handling

### DIFF
--- a/src/caps/header.rs
+++ b/src/caps/header.rs
@@ -2,6 +2,7 @@ use crate::bar::BAR;
 use crate::caps::binary_parser::BinaryParser;
 use crate::error::{Error, Result};
 use pci_ids::{Device, FromId, Subclass, Vendor};
+
 use std::ops::Range;
 
 pub trait CommonHeader {
@@ -156,6 +157,19 @@ pub trait CommonHeader {
         Ok(text)
     }
 
+    fn bars_string(&self) -> Result<Vec<String>> {
+        let mut text = vec![];
+
+        for bar in self.bars()? {
+            if !bar.is_allocated() {
+                continue;
+            }
+            text.push(format!("{}", bar))
+        }
+
+        Ok(text)
+    }
+
     fn header_layout(b: &[u8]) -> Result<u8> {
         let layout = BinaryParser::le8(
             b,
@@ -196,6 +210,9 @@ impl CommonHeader for Type0Header {
 
         if verbosity >= 1 {
             text = format!("{}\n\t{}", text, self.subsytem_string()?);
+            for bar in self.bars_string()? {
+                text = format!("{}\n\t{}", text, bar);
+            }
         }
 
         Ok(text.trim().to_string())


### PR DESCRIPTION
Add the ability to show BARs in the verbose mode. This is minimal
handling and has a long ways to go to support BAR sizes and expansion
ROMs as well.

[example]:
$ cargo run --bin lspci -- -vs00:02.0
   Compiling pciutils v0.1.0 (/home/ekohandel/sandbox/pciutils.rs)
    Finished dev [unoptimized + debuginfo] target(s) in 1.01s
     Running `target/debug/lspci '-vs00:02.0'`
00:02.0 VGA compatible controller: Intel Corporation Alder Lake-UP3 GT2 [Iris Xe Graphics] (rev 0c)
        Subsystem: Vendor 1558 Device 7718
        Memory at 81000000 (64-bit, non-prefetchable)
        Memory at 90000000 (64-bit, prefetchable)
        I/O ports at 1000
        Kernel driver in use: i915
        Kernel modules: i915

$ lspci -vs00:02.0
00:02.0 VGA compatible controller: Intel Corporation Alder Lake-UP3 GT2 [Iris Xe Graphics] (rev 0c) (prog-if 00 [VGA controller])
        DeviceName: VGA compatible controller
        Subsystem: CLEVO/KAPOK Computer Device 7718
        Flags: bus master, fast devsel, latency 0, IRQ 172, IOMMU group 0
        Memory at 81000000 (64-bit, non-prefetchable) [size=16M]
        Memory at 90000000 (64-bit, prefetchable) [size=256M]
        I/O ports at 1000 [size=64]
        Expansion ROM at 000c0000 [virtual] [disabled] [size=128K]
        Capabilities: <access denied>
        Kernel driver in use: i915
        Kernel modules: i915