### PR TITLE
feat: minimal capability discovery

### DIFF
--- a/src/access/dump.rs
+++ b/src/access/dump.rs
@@ -1,0 +1,30 @@
+use crate::access::Access;
+use crate::error::Result;
+
+pub struct DumpAccess {
+    dump: Vec<u8>,
+}
+
+impl DumpAccess {
+    pub fn new(dump: &[u8]) -> DumpAccess {
+        DumpAccess {
+            dump: dump.to_vec(),
+        }
+    }
+}
+
+impl Access for DumpAccess {
+    fn read(&self, offset: u64, length: usize) -> Result<Vec<u8>> {
+        Ok(self
+            .dump
+            .clone()
+            .into_iter()
+            .skip(offset as usize)
+            .take(length)
+            .collect())
+    }
+
+    fn write(&self, _offset: u64, buffer: &[u8]) -> Result<usize> {
+        Ok(buffer.len())
+    }
+}

--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -1,0 +1,9 @@
+pub mod dump;
+pub mod sysfs;
+
+use crate::error::Result;
+
+pub trait Access {
+    fn read(&self, offset: u64, length: usize) -> Result<Vec<u8>>;
+    fn write(&self, offset: u64, value: &[u8]) -> Result<usize>;
+}

--- a/src/bdf.rs
+++ b/src/bdf.rs
@@ -3,7 +3,7 @@ use log::trace;
 use std::fmt::Display;
 use std::str::FromStr;
 
-#[derive(Debug, Eq, Ord, PartialOrd, Clone)]
+#[derive(Debug, Eq, Ord, PartialOrd, Clone, Copy)]
 pub struct BusDeviceFunction {
     domain: Option<u16>,
     bus: Option<u8>,

--- a/src/bin/lspci.rs
+++ b/src/bin/lspci.rs
@@ -1,6 +1,6 @@
+use pciutils::access::sysfs::Sysfs;
 use pciutils::error::Result;
 use pciutils::parser::Parser;
-use pciutils::sysfs::Sysfs;
 
 use pretty_hex::{config_hex, HexConfig};
 

--- a/src/caps/mod.rs
+++ b/src/caps/mod.rs
@@ -1,2 +1,73 @@
+use crate::access::Access;
+use crate::error::Result;
+use std::io::{Error, ErrorKind};
+use std::rc::Rc;
+
+use self::power_management::PowerManagementCapability;
+use self::unknown::UnknownCapability;
+
 pub mod binary_parser;
 pub mod header;
+pub mod power_management;
+pub mod unknown;
+
+pub trait Capability {
+    fn cap_string(&self, _verbosity: u8) -> Result<String>;
+    fn offset(&self) -> Result<u64>;
+}
+
+pub struct CapabilityFactory {
+    access: Rc<Box<dyn Access>>,
+}
+
+impl CapabilityFactory {
+    pub fn new(access: Box<dyn Access>) -> CapabilityFactory {
+        CapabilityFactory {
+            access: Rc::new(access),
+        }
+    }
+
+    pub fn scan(&self) -> Result<Vec<Box<dyn Capability>>> {
+        let capabilities = self.scan_trad()?;
+
+        Ok(capabilities)
+    }
+
+    fn scan_trad(&self) -> Result<Vec<Box<dyn Capability>>> {
+        let mut capabilities = vec![];
+
+        let mut offset: u8 = self.access.read(0x34, 1)?.pop().unwrap_or_default();
+
+        while offset != 0 {
+            let id = self.access.read(offset.into(), 1)?.pop().ok_or(Error::new(
+                ErrorKind::PermissionDenied,
+                format!("Unable to read offset {}", offset),
+            ))?;
+            capabilities.push(self.new_trad(id, offset)?);
+
+            offset = self
+                .access
+                .read(offset as u64 + 1, 1)?
+                .pop()
+                .ok_or(Error::new(
+                    ErrorKind::PermissionDenied,
+                    format!("Unable to read offset {}", offset + 1),
+                ))?;
+        }
+
+        Ok(capabilities)
+    }
+
+    fn new_trad(&self, id: u8, offset: u8) -> Result<Box<dyn Capability>> {
+        match id {
+            0x1 => Ok(Box::new(PowerManagementCapability::new(
+                Rc::clone(&self.access),
+                offset,
+            )?)),
+            _ => Ok(Box::new(UnknownCapability::new(
+                Rc::clone(&self.access),
+                offset,
+            )?)),
+        }
+    }
+}

--- a/src/caps/power_management.rs
+++ b/src/caps/power_management.rs
@@ -1,0 +1,42 @@
+use crate::access::Access;
+use crate::error::{Error, Result};
+use std::fmt::Display;
+use std::rc::Rc;
+
+use super::Capability;
+
+pub struct PowerManagementCapability {
+    access: Rc<Box<dyn Access>>,
+    offset: u8,
+}
+
+impl PowerManagementCapability {
+    pub fn new(access: Rc<Box<dyn Access>>, offset: u8) -> Result<PowerManagementCapability> {
+        Ok(PowerManagementCapability { access, offset })
+    }
+}
+
+impl Capability for PowerManagementCapability {
+    fn cap_string(&self, _verbosity: u8) -> Result<String> {
+        Ok(format!(
+            "Power Management version {}\n",
+            self.access
+                .read(self.offset as u64 + 2, 1)?
+                .pop()
+                .ok_or(Error::unknown_capability(0))?
+                & 0x7
+        )
+        .trim()
+        .to_string())
+    }
+
+    fn offset(&self) -> Result<u64> {
+        Ok(self.offset.into())
+    }
+}
+
+impl Display for PowerManagementCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.cap_string(0)?)
+    }
+}

--- a/src/caps/unknown.rs
+++ b/src/caps/unknown.rs
@@ -1,0 +1,38 @@
+use std::fmt::Display;
+use std::rc::Rc;
+
+use crate::access::Access;
+use crate::caps::Capability;
+use crate::error::Result;
+
+pub struct UnknownCapability {
+    access: Rc<Box<dyn Access>>,
+    offset: u8,
+}
+
+impl UnknownCapability {
+    pub fn new(access: Rc<Box<dyn Access>>, offset: u8) -> Result<UnknownCapability> {
+        Ok(UnknownCapability { access, offset })
+    }
+}
+
+impl Capability for UnknownCapability {
+    fn cap_string(&self, _verbosity: u8) -> Result<String> {
+        let id = self
+            .access
+            .read(self.offset.into(), 1)?
+            .pop()
+            .unwrap_or_default();
+        Ok(format!("Capability {:#x} at {:#x}", id, self.offset))
+    }
+
+    fn offset(&self) -> Result<u64> {
+        Ok(self.offset.into())
+    }
+}
+
+impl Display for UnknownCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.cap_string(0)?)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum ErrorKind {
     IoError(std::io::ErrorKind),
     FormatError,
     SliceParseError,
+    UnknownCapabilityId,
 }
 
 #[derive(Debug, PartialEq)]
@@ -48,6 +49,14 @@ impl Error {
         let message = format!("Index range {}:{} outside of 0:{}", r.start, r.end, b.len());
         Error {
             error_kind: ErrorKind::SliceParseError,
+            message,
+        }
+    }
+
+    pub fn unknown_capability(id: u8) -> Error {
+        let message = format!("Unknown capability id:{}", id);
+        Error {
+            error_kind: ErrorKind::UnknownCapabilityId,
             message,
         }
     }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,6 +1,6 @@
+use crate::access::sysfs::Sysfs;
 use crate::bdf::BusDeviceFunction;
 use crate::error::Result;
-use crate::sysfs::Sysfs;
 use std::fs::read_link;
 
 #[derive(Debug)]
@@ -15,11 +15,7 @@ impl Kernel {
         ))
     }
 
-    pub fn driver_text(&self, bdf: &BusDeviceFunction, verbosity: u8) -> Result<String> {
-        if verbosity == 0 {
-            return Ok(String::new());
-        }
-
+    pub fn driver_text(&self, bdf: &BusDeviceFunction, _verbosity: u8) -> Result<String> {
         let driver_symlink = Sysfs::get_function_sub_path(bdf, "driver");
         let driver_path = read_link(driver_symlink);
 
@@ -36,11 +32,7 @@ impl Kernel {
         ))
     }
 
-    pub fn module_text(&self, bdf: &BusDeviceFunction, verbosity: u8) -> Result<String> {
-        if verbosity == 0 {
-            return Ok(String::new());
-        }
-
+    pub fn module_text(&self, bdf: &BusDeviceFunction, _verbosity: u8) -> Result<String> {
         let module_symlink = Sysfs::get_function_sub_path(bdf, "driver/module");
         let module_path = read_link(module_symlink);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod access;
 pub mod bar;
 pub mod bdf;
 pub mod caps;
@@ -5,5 +6,4 @@ pub mod error;
 pub mod function;
 pub mod kernel;
 pub mod parser;
-pub mod sysfs;
 pub mod vdc;


### PR DESCRIPTION
Add the ability to discover traditional capabilities and display them. Currently only version field of the power management capability is parsed. This is mostly the framework to support further capability implementation.

Unprivileged run:

$ cargo run --bin lspci -- -vs2d:00.0
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `./lspci '-vs2d:00.0'`
2d:00.0 SD Host controller: O2 Micro, Inc. SD/MMC Card Reader Controller (rev 01)
        Subsystem: Vendor 1217 Device 0002
        Memory at 80500000 (32-bit, non-prefetchable)
        Memory at 80501000 (32-bit, non-prefetchable)
        Capabilities: <access denied>
        Kernel driver in use: sdhci-pci
        Kernel modules: sdhci_pci

$ lspci -vs2d:00.0
2d:00.0 SD Host controller: O2 Micro, Inc. SD/MMC Card Reader Controller (rev 01) (prog-if 01)
        Subsystem: O2 Micro, Inc. SD/MMC Card Reader Controller
        Physical Slot: 5
        Flags: bus master, fast devsel, latency 0, IRQ 154, IOMMU group 14
        Memory at 80500000 (32-bit, non-prefetchable) [size=4K]
        Memory at 80501000 (32-bit, non-prefetchable) [size=2K]
        Capabilities: <access denied>
        Kernel driver in use: sdhci-pci
        Kernel modules: sdhci_pci

Privileged run:

$ sudo -E bash -c 'cargo run --bin lspci -- -vs2d:00.0'
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `./lspci '-vs2d:00.0'`
2d:00.0 SD Host controller: O2 Micro, Inc. SD/MMC Card Reader Controller (rev 01)
        Subsystem: Vendor 1217 Device 0002
        Memory at 80500000 (32-bit, non-prefetchable)
        Memory at 80501000 (32-bit, non-prefetchable)
        Capabilities: [6c] Power Management version 3
        Capabilities: [48] Capability 0x5 at 0x48
        Capabilities: [80] Capability 0x10 at 0x80
        Kernel driver in use: sdhci-pci
        Kernel modules: sdhci_pci

$ sudo lspci -vs2d:00.0
2d:00.0 SD Host controller: O2 Micro, Inc. SD/MMC Card Reader Controller (rev 01) (prog-if 01)
        Subsystem: O2 Micro, Inc. SD/MMC Card Reader Controller
        Physical Slot: 5
        Flags: bus master, fast devsel, latency 0, IRQ 154, IOMMU group 14
        Memory at 80500000 (32-bit, non-prefetchable) [size=4K]
        Memory at 80501000 (32-bit, non-prefetchable) [size=2K]
        Capabilities: [6c] Power Management version 3
        Capabilities: [48] MSI: Enable+ Count=1/1 Maskable+ 64bit+
        Capabilities: [80] Express Endpoint, MSI 00
        Capabilities: [100] Virtual Channel
        Capabilities: [200] Advanced Error Reporting
        Capabilities: [230] Latency Tolerance Reporting
        Capabilities: [240] L1 PM Substates
        Kernel driver in use: sdhci-pci
        Kernel modules: sdhci_pci