### PR TITLE
refactor: consolidate id and next reading

### DIFF
--- a/src/caps/unknown.rs
+++ b/src/caps/unknown.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::io::{Error, ErrorKind};
 use std::ops::Range;
 use std::rc::Rc;
 
@@ -17,15 +18,25 @@ impl UnknownCapability {
     pub fn new(access: Rc<Box<dyn Access>>, offset: u8) -> Result<UnknownCapability> {
         Ok(UnknownCapability { access, offset })
     }
+
+    pub fn id(access: &Rc<Box<dyn Access>>, offset: u8) -> Result<u8> {
+        Ok(access.read(offset.into(), 1)?.pop().ok_or(Error::new(
+            ErrorKind::PermissionDenied,
+            format!("Unable to read offset {}", offset + 1),
+        ))?)
+    }
+
+    pub fn next(access: &Rc<Box<dyn Access>>, offset: u8) -> Result<u8> {
+        Ok(access.read(offset as u64 + 1, 1)?.pop().ok_or(Error::new(
+            ErrorKind::PermissionDenied,
+            format!("Unable to read offset {}", offset + 1),
+        ))?)
+    }
 }
 
 impl Capability for UnknownCapability {
     fn cap_string(&self, _verbosity: u8) -> Result<String> {
-        let id = self
-            .access
-            .read(self.offset.into(), 1)?
-            .pop()
-            .unwrap_or_default();
+        let id = Self::id(&self.access, self.offset)?;
         Ok(format!("Capability {:#x} at {:#x}", id, self.offset))
     }
 
@@ -49,14 +60,25 @@ impl UnknownExtendedCapability {
     pub fn new(access: Rc<Box<dyn Access>>, offset: u16) -> Result<UnknownExtendedCapability> {
         Ok(UnknownExtendedCapability { access, offset })
     }
+
+    pub fn id(access: &Rc<Box<dyn Access>>, offset: u16) -> Result<u16> {
+        binary_parser::BinaryParser::le16(
+            &access.read(offset.into(), 2)?,
+            Range { start: 0, end: 2 },
+        )
+    }
+
+    pub fn next(access: &Rc<Box<dyn Access>>, offset: u16) -> Result<u16> {
+        Ok(binary_parser::BinaryParser::le16(
+            &access.read(offset as u64 + 2, 2)?,
+            Range { start: 0, end: 2 },
+        )? >> 4)
+    }
 }
 
 impl Capability for UnknownExtendedCapability {
     fn cap_string(&self, _verbosity: u8) -> Result<String> {
-        let id = binary_parser::BinaryParser::le16(
-            &self.access.read(self.offset.into(), 2)?,
-            Range { start: 0, end: 2 },
-        )?;
+        let id = Self::id(&self.access, self.offset)?;
         Ok(format!("Capability {:#x} at {:#x}", id, self.offset))
     }
 


### PR DESCRIPTION
Use functions on UnknownCapability and UnknownExtendedCapability to access id and next values.