### PR TITLE
feat: add power management flags parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "nom",
  "pci-ids",
  "pretty-hex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ env_logger = "0.10.0"
 log = "0.4.20"
 pci-ids = "0.2.5"
 pretty-hex = "0.3.0"
-
+nom = "7.1.3"

--- a/src/caps/mod.rs
+++ b/src/caps/mod.rs
@@ -1,6 +1,7 @@
 use crate::access::Access;
 use crate::error::Result;
 use std::collections::HashSet;
+use std::fmt::Display;
 use std::rc::Rc;
 
 use self::header::{CommonHeader, Header};
@@ -11,6 +12,31 @@ pub mod binary_parser;
 pub mod header;
 pub mod power_management;
 pub mod unknown;
+
+pub struct Flag {
+    name: &'static str,
+    value: bool,
+}
+
+impl Flag {
+    pub fn new(name: &'static str, value: bool) -> Self {
+        Self { name, value }
+    }
+}
+
+impl Display for Flag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{}",
+            self.name,
+            match self.value {
+                true => "+",
+                false => "-",
+            }
+        )
+    }
+}
 
 pub trait Capability {
     fn cap_string(&self, _verbosity: u8) -> Result<String>;

--- a/src/caps/power_management.rs
+++ b/src/caps/power_management.rs
@@ -1,33 +1,96 @@
 use crate::access::Access;
-use crate::error::{Error, Result};
+use crate::error::Result;
+use nom::sequence::tuple;
+use nom::IResult;
+use nom::{bits, streaming::take};
 use std::fmt::Display;
 use std::rc::Rc;
 
 use super::Capability;
+use super::Flag;
+
+type IResultCapability<'a> = IResult<&'a [u8], (u8, u8, u8, u8, u8, u8, u8, u8)>;
 
 pub struct PowerManagementCapability {
-    access: Rc<Box<dyn Access>>,
+    _access: Rc<Box<dyn Access>>,
     offset: u8,
+
+    version: u8,
+    pme_clock: Flag,
+    _immediate_readiness_on_return_to_d0: Flag,
+    driver_specific_initialization: Flag,
+    aux_current: AuxCurrent,
+    d1_support: Flag,
+    d2_support: Flag,
+    pme_support: PmeSupport,
 }
 
 impl PowerManagementCapability {
     pub fn new(access: Rc<Box<dyn Access>>, offset: u8) -> Result<PowerManagementCapability> {
-        Ok(PowerManagementCapability { access, offset })
+        let mut raw = access.read(offset as u64 + 2, 2)?;
+        // TODO check endianness
+        raw.reverse();
+        let (
+            _,
+            (
+                pme_support,
+                d2_support,
+                d1_support,
+                aux_current,
+                driver_specific_initialization,
+                immediate_readiness_on_return_to_d0,
+                pme_clock,
+                version,
+            ),
+        ) = Self::parse(&raw).unwrap();
+        Ok(PowerManagementCapability {
+            _access: access,
+            offset,
+            pme_support: PmeSupport::new(pme_support),
+            d2_support: Flag::new("D2", d2_support != 0),
+            d1_support: Flag::new("D1", d1_support != 0),
+            aux_current: AuxCurrent::new(aux_current),
+            driver_specific_initialization: Flag::new("DSI", driver_specific_initialization != 0),
+            _immediate_readiness_on_return_to_d0: Flag::new(
+                " ",
+                immediate_readiness_on_return_to_d0 != 0,
+            ),
+            pme_clock: Flag::new("PMEClk", pme_clock != 0),
+            version,
+        })
+    }
+
+    fn parse(input: &[u8]) -> IResultCapability {
+        bits::<_, _, nom::error::Error<(&[u8], usize)>, _, _>(tuple((
+            take(5usize), // PME_Support
+            take(1usize), // D2_Support
+            take(1usize), // D1_Support
+            take(3usize), // Aux_Current
+            take(1usize), // Driver Specific Initialization
+            take(1usize), // Immediate_Readiness_on_Return_to_D0
+            take(1usize), // PME Clock
+            take(3usize), // Version
+        )))(input)
     }
 }
 
 impl Capability for PowerManagementCapability {
-    fn cap_string(&self, _verbosity: u8) -> Result<String> {
-        Ok(format!(
-            "Power Management version {}\n",
-            self.access
-                .read(self.offset as u64 + 2, 1)?
-                .pop()
-                .ok_or(Error::unknown_capability(0))?
-                & 0x7
-        )
-        .trim()
-        .to_string())
+    fn cap_string(&self, verbosity: u8) -> Result<String> {
+        let mut text = format!("Power Management version {}\n", self.version);
+
+        if verbosity >= 2 {
+            text += &format!(
+                "\t\tFlags: {} {} {} {} {} {}\n",
+                self.pme_clock,
+                self.driver_specific_initialization,
+                self.d1_support,
+                self.d2_support,
+                self.aux_current,
+                self.pme_support
+            );
+        }
+
+        Ok(text.trim().to_string())
     }
 
     fn offset(&self) -> Result<u64> {
@@ -38,5 +101,64 @@ impl Capability for PowerManagementCapability {
 impl Display for PowerManagementCapability {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.cap_string(0)?)
+    }
+}
+
+pub struct AuxCurrent {
+    current: u8,
+}
+
+impl AuxCurrent {
+    pub fn new(current: u8) -> AuxCurrent {
+        AuxCurrent { current }
+    }
+}
+
+impl Display for AuxCurrent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "AuxCurrent={}mA",
+            match self.current {
+                1 => 55,
+                2 => 100,
+                3 => 160,
+                4 => 220,
+                5 => 270,
+                6 => 320,
+                7 => 375,
+                _ => 0,
+            }
+        )
+    }
+}
+
+pub struct PmeSupport {
+    d0: Flag,
+    d1: Flag,
+    d2: Flag,
+    d3_hot: Flag,
+    d3_cold: Flag,
+}
+
+impl PmeSupport {
+    pub fn new(states: u8) -> PmeSupport {
+        PmeSupport {
+            d0: Flag::new("D0", states & 0b00001 != 0),
+            d1: Flag::new("D1", states & 0b00010 != 0),
+            d2: Flag::new("D2", states & 0b00100 != 0),
+            d3_hot: Flag::new("D3hot", states & 0b01000 != 0),
+            d3_cold: Flag::new("D3cold", states & 0b10000 != 0),
+        }
+    }
+}
+
+impl Display for PmeSupport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PME({},{},{},{},{})",
+            self.d0, self.d1, self.d2, self.d3_hot, self.d3_cold
+        )
     }
 }


### PR DESCRIPTION
Add the ability to parse all the capability fields and display them as flags. There is no support for the status fields in this commit.

$ sudo -E bash -c 'cargo run --bin lspci -- -vvs2d:00.0'
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/lspci '-vvs2d:00.0'`
2d:00.0 SD Host controller: O2 Micro, Inc. SD/MMC Card Reader Controller (rev 01) ------------------------ >8 ------------------------
        Capabilities: [6c] Power Management version 3
                Flags: PMEClk- DSI- D1- D2- AuxCurrent=55mA PME(D0-,D1-,D2-,D3hot+,D3cold+)
------------------------ >8 ------------------------

$ sudo lspci -vvs2d:00.0
2d:00.0 SD Host controller: O2 Micro, Inc. SD/MMC Card Reader Controller (rev 01) (prog-if 01) ------------------------ >8 ------------------------
        Capabilities: [6c] Power Management version 3
                Flags: PMEClk- DSI- D1- D2- AuxCurrent=55mA PME(D0-,D1-,D2-,D3hot+,D3cold+)
                Status: D0 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
------------------------ >8 ------------------------